### PR TITLE
Upgrade node-problem-detector base chart and app to v0.8.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade node-problem-detector base chart and app to v0.8.20
+
 ## [0.4.0] - 2024-08-01
 
 ### Changed

--- a/helm/node-problem-detector/Chart.lock
+++ b/helm/node-problem-detector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: node-problem-detector
-  repository: https://charts.deliveryhero.io/
-  version: 2.3.11
-digest: sha256:5769877cf29ff317cd399eda21a7b9ef42f46abe98e571eb1cf8e56488b2ec5b
-generated: "2023-10-04T15:09:26.191197968+02:00"
+  repository: oci://ghcr.io/deliveryhero/helm-charts
+  version: 2.3.21
+digest: sha256:d1013473b747608352f39c67a24e39f7e109192f3df3b2873f27aa4043d5d6b2
+generated: "2025-07-02T12:18:27.694221+02:00"

--- a/helm/node-problem-detector/Chart.yaml
+++ b/helm/node-problem-detector/Chart.yaml
@@ -9,10 +9,10 @@ description: A helm chart for running node-problem-detector on a cluster.
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 type: application
 version: "0.4.0"
-appVersion: v0.8.14
+appVersion: v0.8.20
 annotations:
   application.giantswarm.io/team: "phoenix"
 dependencies:
   - name: node-problem-detector
-    version: "2.3.11"
-    repository: "https://charts.deliveryhero.io/"
+    version: "2.3.21"
+    repository: "oci://ghcr.io/deliveryhero/helm-charts"


### PR DESCRIPTION
Not really needed, just to get latest improvements and fixes. Works fine in testing.

Towards https://github.com/giantswarm/roadmap/issues/3501